### PR TITLE
Send TheTradeDesk Unified ID to the ad server

### DIFF
--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -22,6 +22,7 @@ type StrAdSeverParams struct {
 	Iframe             bool
 	Height             uint64
 	Width              uint64
+	TheTradeDeskUserId string
 }
 
 type StrOpenRTBInterface interface {
@@ -68,6 +69,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	}
 
 	pKey := strImpParams.Pkey
+	userInfo := s.Util.parseUserExt(request.User)
 
 	var height, width uint64
 	if len(strImpParams.IframeSize) >= 2 {
@@ -82,11 +84,12 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 			Pkey:               pKey,
 			BidID:              imp.ID,
 			ConsentRequired:    s.Util.gdprApplies(request),
-			ConsentString:      s.Util.gdprConsentString(request),
+			ConsentString:      userInfo.Consent,
 			Iframe:             strImpParams.Iframe,
 			Height:             height,
 			Width:              width,
 			InstantPlayCapable: s.Util.canAutoPlayVideo(request.Device.UA, s.UserAgentParsers),
+			TheTradeDeskUserId: userInfo.TtdUid,
 		}),
 		Body:    nil,
 		Headers: headers,
@@ -143,6 +146,9 @@ func (h StrUriHelper) buildUri(params StrAdSeverParams) string {
 	v.Set("bidId", params.BidID)
 	v.Set("consent_required", fmt.Sprintf("%t", params.ConsentRequired))
 	v.Set("consent_string", params.ConsentString)
+	if params.TheTradeDeskUserId != "" {
+		v.Set("ttduid", params.TheTradeDeskUserId)
+	}
 
 	v.Set("instant_play_capable", fmt.Sprintf("%t", params.InstantPlayCapable))
 	v.Set("stayInIframe", fmt.Sprintf("%t", params.Iframe))

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -284,6 +284,7 @@ func TestBuildUri(t *testing.T) {
 				Iframe:             false,
 				Height:             20,
 				Width:              30,
+				TheTradeDeskUserId: "ttd123",
 			},
 			expected: []string{
 				"http://abc.com?",
@@ -297,6 +298,7 @@ func TestBuildUri(t *testing.T) {
 				"width=30",
 				"supplyId=FGMrCMMc",
 				"strVersion=" + strVersion,
+				"ttduid=ttd123",
 			},
 		},
 	}

--- a/adapters/sharethrough/utils.go
+++ b/adapters/sharethrough/utils.go
@@ -20,7 +20,7 @@ const minSafariVersion = 10
 
 type UtilityInterface interface {
 	gdprApplies(*openrtb.BidRequest) bool
-	gdprConsentString(*openrtb.BidRequest) string
+	parseUserExt(*openrtb.User) userInfo
 
 	getAdMarkup(openrtb_ext.ExtImpSharethroughResponse, *StrAdSeverParams) (string, error)
 	getPlacementSize([]openrtb.Format) (uint64, uint64)
@@ -35,6 +35,16 @@ type UtilityInterface interface {
 }
 
 type Util struct{}
+
+type userExt struct {
+	Consent string                   `json:"consent,omitempty"`
+	Eids    []openrtb_ext.ExtUserEid `json:"eids,omitempty"`
+}
+
+type userInfo struct {
+	Consent string
+	TtdUid  string
+}
 
 func (u Util) getAdMarkup(strResp openrtb_ext.ExtImpSharethroughResponse, params *StrAdSeverParams) (string, error) {
 	strRespId := fmt.Sprintf("str_response_%s", strResp.BidID)
@@ -183,17 +193,23 @@ func (u Util) gdprApplies(request *openrtb.BidRequest) bool {
 	return gdprApplies != 0
 }
 
-func (u Util) gdprConsentString(request *openrtb.BidRequest) string {
-	var consentString string
-
-	if request.User != nil {
-		if jsonExtUser, err := request.User.Ext.MarshalJSON(); err == nil {
-			// empty string is the return value if error, so no need to handle
-			consentString, _ = jsonparser.GetString(jsonExtUser, "consent")
+func (u Util) parseUserExt(user *openrtb.User) userInfo {
+	var userExt userExt
+	var unifiedId string
+	var gdprConsentString string
+	if user != nil && user.Ext != nil {
+		if err := json.Unmarshal(user.Ext, &userExt); err == nil {
+			gdprConsentString = userExt.Consent
+			for i := 0; i < len(userExt.Eids); i++ {
+				if userExt.Eids[i].Source == "adserver.org" {
+					unifiedId = userExt.Eids[i].Uids[0].ID
+					break
+				}
+			}
 		}
 	}
 
-	return consentString
+	return userInfo{Consent: gdprConsentString, TtdUid: unifiedId}
 }
 
 func (u Util) parseDomain(fullUrl string) string {


### PR DESCRIPTION
Expected User Ext:
```json
{
    "user": {
        "ext": {
            "eids": [{
                "source": "adserver.org",
                "uids": [{
                    "id": "111111111111",
                    "ext": {
                        "rtiPartner": "TDID"
                    }
                }]
            },
            {
                "source": "pubcommon",
                "uids": [{
                    "id":"11111111"
                }]
            }
            ],
            "digitrust": {
                "id": "11111111111",
                "keyv": 4
            }
        }
    }
}
```
As I understood it from [here](https://github.com/prebid/Prebid.js/issues/3046), the source `adserver.org` represents the trade desk. Also explains why `rtiPartner` is set to `TDID` I guess.

https://www.pivotaltracker.com/story/show/167548851