### PR TITLE
Refactor the way the ad payload is passed to the ad markup

### DIFF
--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -27,7 +27,7 @@ type StrAdSeverParams struct {
 
 type StrOpenRTBInterface interface {
 	requestFromOpenRTB(openrtb.Imp, *openrtb.BidRequest, string) (*adapters.RequestData, error)
-	responseToOpenRTB(openrtb_ext.ExtImpSharethroughResponse, *adapters.RequestData) (*adapters.BidderResponse, []error)
+	responseToOpenRTB([]byte, *adapters.RequestData) (*adapters.BidderResponse, []error)
 }
 
 type StrAdServerUriInterface interface {
@@ -64,7 +64,7 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	if err := json.Unmarshal(imp.Ext, &strImpExt); err != nil {
 		return nil, err
 	}
-	var strImpParams openrtb_ext.ExtImpSharethroughExt
+	var strImpParams openrtb_ext.ExtImpSharethrough
 	if err := json.Unmarshal(strImpExt.Bidder, &strImpParams); err != nil {
 		return nil, err
 	}
@@ -97,8 +97,13 @@ func (s StrOpenRTBTranslator) requestFromOpenRTB(imp openrtb.Imp, request *openr
 	}, nil
 }
 
-func (s StrOpenRTBTranslator) responseToOpenRTB(strResp openrtb_ext.ExtImpSharethroughResponse, btlrReq *adapters.RequestData) (*adapters.BidderResponse, []error) {
+func (s StrOpenRTBTranslator) responseToOpenRTB(strRawResp []byte, btlrReq *adapters.RequestData) (*adapters.BidderResponse, []error) {
 	var errs []error
+
+	var strResp openrtb_ext.ExtImpSharethroughResponse
+	if err := json.Unmarshal(strRawResp, &strResp); err != nil {
+		return nil, []error{&errortypes.BadInput{Message: "Unable to parse response JSON"}}
+	}
 	bidResponse := adapters.NewBidderResponse()
 
 	bidResponse.Currency = "USD"
@@ -116,7 +121,7 @@ func (s StrOpenRTBTranslator) responseToOpenRTB(strResp openrtb_ext.ExtImpSharet
 		return nil, errs
 	}
 
-	adm, admErr := s.Util.getAdMarkup(strResp, btlrParams)
+	adm, admErr := s.Util.getAdMarkup(strRawResp, strResp, btlrParams)
 	if admErr != nil {
 		errs = append(errs, &errortypes.BadServerResponse{Message: admErr.Error()})
 		return nil, errs

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -165,7 +165,7 @@ func assertBidderResponseEquals(t *testing.T, testName string, expected adapters
 func TestSuccessResponseToOpenRTB(t *testing.T) {
 	tests := map[string]struct {
 		inputButlerReq  *adapters.RequestData
-		inputStrResp    openrtb_ext.ExtImpSharethroughResponse
+		inputStrResp    []byte
 		expectedSuccess *adapters.BidderResponse
 		expectedErrors  []error
 	}{
@@ -173,18 +173,7 @@ func TestSuccessResponseToOpenRTB(t *testing.T) {
 			inputButlerReq: &adapters.RequestData{
 				Uri: "http://uri.com?placement_key=pkey&bidId=bidid&height=20&width=30",
 			},
-			inputStrResp: openrtb_ext.ExtImpSharethroughResponse{
-				AdServerRequestID: "arid",
-				BidID:             "bid",
-				Creatives: []openrtb_ext.ExtImpSharethroughCreative{{
-					CPM: 10,
-					Metadata: openrtb_ext.ExtImpSharethroughCreativeMetadata{
-						CampaignKey: "cmpKey",
-						CreativeKey: "creaKey",
-						DealID:      "dealId",
-					},
-				}},
-			},
+			inputStrResp: []byte(`{ "adserverRequestId": "arid", "bidId": "bid", "creatives": [{"cpm": 10, "creative": {"campaign_key": "cmpKey", "creative_key": "creaKey", "deal_id": "dealId"}}] }`),
 			expectedSuccess: &adapters.BidderResponse{
 				Bids: []*adapters.TypedBid{{
 					BidType: openrtb_ext.BidTypeNative,
@@ -218,15 +207,13 @@ func TestSuccessResponseToOpenRTB(t *testing.T) {
 func TestFailResponseToOpenRTB(t *testing.T) {
 	tests := map[string]struct {
 		inputButlerReq  *adapters.RequestData
-		inputStrResp    openrtb_ext.ExtImpSharethroughResponse
+		inputStrResp    []byte
 		expectedSuccess *adapters.BidderResponse
 		expectedErrors  []error
 	}{
 		"Returns nil if no creatives provided": {
-			inputButlerReq: &adapters.RequestData{},
-			inputStrResp: openrtb_ext.ExtImpSharethroughResponse{
-				Creatives: []openrtb_ext.ExtImpSharethroughCreative{},
-			},
+			inputButlerReq:  &adapters.RequestData{},
+			inputStrResp:    []byte(`{}`),
 			expectedSuccess: nil,
 			expectedErrors: []error{
 				&errortypes.BadInput{Message: "No creative provided"},
@@ -236,12 +223,18 @@ func TestFailResponseToOpenRTB(t *testing.T) {
 			inputButlerReq: &adapters.RequestData{
 				Uri: "wrong format url",
 			},
-			inputStrResp: openrtb_ext.ExtImpSharethroughResponse{
-				Creatives: []openrtb_ext.ExtImpSharethroughCreative{{}},
-			},
+			inputStrResp:    []byte(`{ "creatives": [{"creative": {}}] }`),
 			expectedSuccess: nil,
 			expectedErrors: []error{
 				&errortypes.BadInput{Message: `strconv.ParseUint: parsing "": invalid syntax`},
+			},
+		},
+		"Returns error if failed parsing body": {
+			inputButlerReq:  &adapters.RequestData{},
+			inputStrResp:    []byte(`{ wrong json`),
+			expectedSuccess: nil,
+			expectedErrors: []error{
+				&errortypes.BadInput{Message: "Unable to parse response JSON"},
 			},
 		},
 	}

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -1,12 +1,10 @@
 package sharethrough
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/http"
 	"regexp"
 )
@@ -68,10 +66,5 @@ func (a SharethroughAdapter) MakeBids(internalRequest *openrtb.BidRequest, exter
 		return nil, []error{fmt.Errorf("unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode)}
 	}
 
-	var strBidResp openrtb_ext.ExtImpSharethroughResponse
-	if err := json.Unmarshal(response.Body, &strBidResp); err != nil {
-		return nil, []error{err}
-	}
-
-	return a.AdServer.responseToOpenRTB(strBidResp, externalRequest)
+	return a.AdServer.responseToOpenRTB(response.Body, externalRequest)
 }

--- a/adapters/sharethrough/sharethrough_test.go
+++ b/adapters/sharethrough/sharethrough_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/errortypes"
-	"github.com/prebid/prebid-server/openrtb_ext"
 	"net/http"
 	"testing"
 )
@@ -21,7 +20,7 @@ func (m MockStrAdServer) requestFromOpenRTB(imp openrtb.Imp, request *openrtb.Bi
 	return m.mockRequestFromOpenRTB()
 }
 
-func (m MockStrAdServer) responseToOpenRTB(strResp openrtb_ext.ExtImpSharethroughResponse, btlrReq *adapters.RequestData) (*adapters.BidderResponse, []error) {
+func (m MockStrAdServer) responseToOpenRTB(strRawResp []byte, btlrReq *adapters.RequestData) (*adapters.BidderResponse, []error) {
 	return m.mockResponseToOpenRTB()
 }
 
@@ -208,13 +207,6 @@ func TestFailureMakeBids(t *testing.T) {
 				StatusCode: http.StatusInternalServerError,
 			},
 			expected: []error{fmt.Errorf("unexpected status code: %d. Run with request.debug = 1 for more info", http.StatusInternalServerError)},
-		},
-		"Returns error if failed parsing body": {
-			inputResponse: &adapters.ResponseData{
-				StatusCode: http.StatusOK,
-				Body:       []byte(`{ wrong json`),
-			},
-			expected: []error{fmt.Errorf("invalid character 'w' looking for beginning of object key string")},
 		},
 		"Passes by errors from responseToOpenRTB": {
 			inputResponse: &adapters.ResponseData{

--- a/adapters/sharethrough/utils.go
+++ b/adapters/sharethrough/utils.go
@@ -22,7 +22,7 @@ type UtilityInterface interface {
 	gdprApplies(*openrtb.BidRequest) bool
 	parseUserExt(*openrtb.User) userInfo
 
-	getAdMarkup(openrtb_ext.ExtImpSharethroughResponse, *StrAdSeverParams) (string, error)
+	getAdMarkup([]byte, openrtb_ext.ExtImpSharethroughResponse, *StrAdSeverParams) (string, error)
 	getPlacementSize([]openrtb.Format) (uint64, uint64)
 
 	canAutoPlayVideo(string, UserAgentParsers) bool
@@ -46,12 +46,8 @@ type userInfo struct {
 	TtdUid  string
 }
 
-func (u Util) getAdMarkup(strResp openrtb_ext.ExtImpSharethroughResponse, params *StrAdSeverParams) (string, error) {
+func (u Util) getAdMarkup(strRawResp []byte, strResp openrtb_ext.ExtImpSharethroughResponse, params *StrAdSeverParams) (string, error) {
 	strRespId := fmt.Sprintf("str_response_%s", strResp.BidID)
-	jsonPayload, err := json.Marshal(strResp)
-	if err != nil {
-		return "", err
-	}
 
 	tmplBody := `
 		<img src="//b.sharethrough.com/butler?type=s2s-win&arid={{.Arid}}" />
@@ -93,7 +89,7 @@ func (u Util) getAdMarkup(strResp openrtb_ext.ExtImpSharethroughResponse, params
 	var buf []byte
 	templatedBuf := bytes.NewBuffer(buf)
 
-	b64EncodedJson := base64.StdEncoding.EncodeToString(jsonPayload)
+	b64EncodedJson := base64.StdEncoding.EncodeToString(strRawResp)
 	err = tmpl.Execute(templatedBuf, struct {
 		Arid           template.JS
 		Pkey           string

--- a/openrtb_ext/imp_sharethrough.go
+++ b/openrtb_ext/imp_sharethrough.go
@@ -1,102 +1,25 @@
 package openrtb_ext
 
-import "encoding/json"
-
 type ExtImpSharethrough struct {
-	PlacementKey string `json:"pkey"`
-	Iframe       bool   `json:"iframe"`
+	Pkey       string `json:"pkey"`
+	Iframe     bool   `json:"iframe"`
+	IframeSize []int  `json:"iframeSize"`
 }
 
 // ExtImpSharethrough defines the contract for bidrequest.imp[i].ext.sharethrough
 type ExtImpSharethroughResponse struct {
 	AdServerRequestID string                       `json:"adserverRequestId"`
 	BidID             string                       `json:"bidId"`
-	CookieSyncUrls    []string                     `json:"cookieSyncUrls"`
 	Creatives         []ExtImpSharethroughCreative `json:"creatives"`
-	Placement         ExtImpSharethroughPlacement  `json:"placement"`
-	StxUserID         string                       `json:"stxUserId"`
 }
 type ExtImpSharethroughCreative struct {
 	AuctionWinID string                             `json:"auctionWinId"`
 	CPM          float64                            `json:"cpm"`
 	Metadata     ExtImpSharethroughCreativeMetadata `json:"creative"`
-	Version      int                                `json:"version"`
 }
 
 type ExtImpSharethroughCreativeMetadata struct {
-	Action                 string                            `json:"action"`
-	Advertiser             string                            `json:"advertiser"`
-	AdvertiserKey          string                            `json:"advertiser_key"`
-	Beacons                ExtImpSharethroughCreativeBeacons `json:"beacons"`
-	BrandLogoURL           string                            `json:"brand_logo_url"`
-	CampaignKey            string                            `json:"campaign_key"`
-	CreativeKey            string                            `json:"creative_key"`
-	CustomEngagementAction string                            `json:"custom_engagement_action"`
-	CustomEngagementLabel  string                            `json:"custom_engagement_label"`
-	CustomEngagementURL    string                            `json:"custom_engagement_url"`
-	DealID                 string                            `json:"deal_id"`
-	Description            string                            `json:"description"`
-	ForceClickToPlay       bool                              `json:"force_click_to_play"`
-	IconURL                string                            `json:"icon_url"`
-	ImpressionHTML         string                            `json:"impression_html"`
-	InstantPlayMobileCount int                               `json:"instant_play_mobile_count"`
-	InstantPlayMobileURL   string                            `json:"instant_play_mobile_url"`
-	MediaURL               string                            `json:"media_url"`
-	ShareURL               string                            `json:"share_url"`
-	SourceID               string                            `json:"source_id"`
-	ThumbnailURL           string                            `json:"thumbnail_url"`
-	Title                  string                            `json:"title"`
-	VariantKey             string                            `json:"variant_key"`
-}
-
-type ExtImpSharethroughCreativeBeacons struct {
-	Click           []string `json:"click"`
-	Impression      []string `json:"impression"`
-	Play            []string `json:"play"`
-	Visible         []string `json:"visible"`
-	WinNotification []string `json:"win-notification"`
-}
-
-type ExtImpSharethroughPlacement struct {
-	AllowInstantPlay      bool                                  `json:"allow_instant_play"`
-	ArticlesBeforeFirstAd int                                   `json:"articles_before_first_ad"`
-	ArticlesBetweenAds    int                                   `json:"articles_between_ads"`
-	Layout                string                                `json:"layout"`
-	Metadata              json.RawMessage                       `json:"metadata"`
-	PlacementAttributes   ExtImpSharethroughPlacementAttributes `json:"placementAttributes"`
-	Status                string                                `json:"status"`
-}
-
-type ExtImpSharethroughPlacementThirdPartyPartner struct {
-	Key string `json:"key"`
-	Tag string `json:"tag"`
-}
-
-type ExtImpSharethroughPlacementAttributes struct {
-	AdServerKey              string                                         `json:"ad_server_key"`
-	AdServerPath             string                                         `json:"ad_server_path"`
-	AllowDynamicCropping     bool                                           `json:"allow_dynamic_cropping"`
-	AppThirdPartyPartners    []string                                       `json:"app_third_party_partners"`
-	CustomCardCSS            string                                         `json:"custom_card_css"`
-	DFPPath                  string                                         `json:"dfp_path"`
-	DirectSellPromotedByText string                                         `json:"direct_sell_promoted_by_text"`
-	Domain                   string                                         `json:"domain"`
-	EnableLinkRedirection    bool                                           `json:"enable_link_redirection"`
-	FeaturedContent          json.RawMessage                                `json:"featured_content"`
-	MaxHeadlineLength        int                                            `json:"max_headline_length"`
-	MultiAdPlacement         bool                                           `json:"multi_ad_placement"`
-	PromotedByText           string                                         `json:"promoted_by_text"`
-	PublisherKey             string                                         `json:"publisher_key"`
-	RenderingPixelOffset     int                                            `json:"rendering_pixel_offset"`
-	SafeFrameSize            []int                                          `json:"safe_frame_size"`
-	SiteKey                  string                                         `json:"site_key"`
-	StrOptOutURL             string                                         `json:"str_opt_out_url"`
-	Template                 string                                         `json:"template"`
-	ThirdPartyPartners       []ExtImpSharethroughPlacementThirdPartyPartner `json:"third_party_partners"`
-}
-
-type ExtImpSharethroughExt struct {
-	Pkey       string `json:"pkey"`
-	Iframe     bool   `json:"iframe"`
-	IframeSize []int  `json:"iframeSize"`
+	CampaignKey string `json:"campaign_key"`
+	CreativeKey string `json:"creative_key"`
+	DealID      string `json:"deal_id"`
 }


### PR DESCRIPTION
Before:
- Decode JSON based on hardcoded ad payload schema
- Then re-encode it to JSON + B64 to put it in the ad markup
- issue: if there's a new field in the ad response, we have to update the code and add it to the schema, push a PR, etc

After:
- JSON schema only has fields that actually matter in the adapter code
- the ad payload is kept raw so we can just B64-encode whatever we got back from the ad server

https://www.pivotaltracker.com/story/show/166100996