### PR TITLE
Blocked advertiser domains, Max timeout, Deadline, Latency Markers

### DIFF
--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -44,7 +44,7 @@ type UserAgentParsers struct {
 
 type ButlerRequestBody struct {
 	BlockedAdvDomains []string `json:"badv,omitempty"`
-	MaxTime           int64    `json:"tmax,omitempty"`
+	MaxTimeout        int64    `json:"tmax,omitempty"`
 }
 
 type StrUriHelper struct {
@@ -161,7 +161,7 @@ func (s StrOpenRTBTranslator) responseToOpenRTB(strRawResp []byte, btlrReq *adap
 func buildBody(request *openrtb.BidRequest) (body []byte, err error) {
 	body, err = json.Marshal(ButlerRequestBody{
 		BlockedAdvDomains: request.BAdv,
-		MaxTime:           request.TMax,
+		MaxTimeout:        request.TMax,
 	})
 
 	return

--- a/adapters/sharethrough/butler.go
+++ b/adapters/sharethrough/butler.go
@@ -44,6 +44,7 @@ type UserAgentParsers struct {
 
 type ButlerRequestBody struct {
 	BlockedAdvDomains []string `json:"badv,omitempty"`
+	MaxTime           int64    `json:"tmax,omitempty"`
 }
 
 type StrUriHelper struct {
@@ -160,6 +161,7 @@ func (s StrOpenRTBTranslator) responseToOpenRTB(strRawResp []byte, btlrReq *adap
 func buildBody(request *openrtb.BidRequest) (body []byte, err error) {
 	body, err = json.Marshal(ButlerRequestBody{
 		BlockedAdvDomains: request.BAdv,
+		MaxTime:           request.TMax,
 	})
 
 	return

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -289,14 +289,14 @@ func TestBuildBody(t *testing.T) {
 		expectedJson  []byte
 		expectedError error
 	}{
-		"Skip badomains if none, tmax default to 10 sec": {
+		"Empty input: skips badomains, tmax default to 10 sec and sets deadline accordingly": {
 			inputRequest: &openrtb.BidRequest{
 				BAdv: nil,
 			},
 			expectedJson:  []byte(`{"tmax":10000, "deadline":"2019-09-12T11:29:10.000123456Z"}`),
 			expectedError: nil,
 		},
-		"Sets badv as list of domains according to Badv": {
+		"Sets badv as list of domains according to Badv (tmax default to 10 sec and sets deadline accordingly)": {
 			inputRequest: &openrtb.BidRequest{
 				BAdv: []string{"dom1.com", "dom2.com"},
 			},

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -85,6 +85,7 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 					IP: "127.0.0.1",
 				},
 				Site: &openrtb.Site{Page: "http://a.domain.com/page"},
+				User: &openrtb.User{},
 			},
 			inputDom: "http://a.domain.com",
 			expected: &adapters.RequestData{

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -280,7 +280,7 @@ func TestBuildBody(t *testing.T) {
 			expectedJson:  []byte(`{}`),
 			expectedError: nil,
 		},
-		"Sets badomain as list of domains according to Badv": {
+		"Sets badv as list of domains according to Badv": {
 			inputRequest: &openrtb.BidRequest{
 				BAdv: []string{"dom1.com", "dom2.com"},
 			},

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -88,12 +88,13 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 				Site: &openrtb.Site{Page: "http://a.domain.com/page"},
 				User: &openrtb.User{},
 				BAdv: []string{"domain1.com", "domain2.com"},
+				TMax: 500,
 			},
 			inputDom: "http://a.domain.com",
 			expected: &adapters.RequestData{
 				Method: "POST",
 				Uri:    "http://abc.com",
-				Body:   []byte(`{"badv":["domain1.com","domain2.com"]}`),
+				Body:   []byte(`{"badv":["domain1.com","domain2.com"],"tmax":500}`),
 				Headers: http.Header{
 					"Content-Type":    []string{"application/json;charset=utf-8"},
 					"Accept":          []string{"application/json"},
@@ -273,7 +274,7 @@ func TestBuildBody(t *testing.T) {
 		expectedJson  []byte
 		expectedError error
 	}{
-		"Returns empty body if no Badv in request": {
+		"Returns empty body if nothing relevant in request": {
 			inputRequest: &openrtb.BidRequest{
 				BAdv: nil,
 			},
@@ -285,6 +286,13 @@ func TestBuildBody(t *testing.T) {
 				BAdv: []string{"dom1.com", "dom2.com"},
 			},
 			expectedJson:  []byte(`{"badv": ["dom1.com", "dom2.com"]}`),
+			expectedError: nil,
+		},
+		"Sets tmax according to Tmax": {
+			inputRequest: &openrtb.BidRequest{
+				TMax: 500,
+			},
+			expectedJson:  []byte(`{"tmax": 500}`),
 			expectedError: nil,
 		},
 	}

--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -93,7 +93,7 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 			expected: &adapters.RequestData{
 				Method: "POST",
 				Uri:    "http://abc.com",
-				Body:   []byte(`{"badomain":["domain1.com","domain2.com"]}`),
+				Body:   []byte(`{"badv":["domain1.com","domain2.com"]}`),
 				Headers: http.Header{
 					"Content-Type":    []string{"application/json;charset=utf-8"},
 					"Accept":          []string{"application/json"},

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -10,7 +10,7 @@ import (
 )
 
 const supplyId = "FGMrCMMc"
-const strVersion = 4
+const strVersion = 5
 
 func NewSharethroughBidder(endpoint string) *SharethroughAdapter {
 	return &SharethroughAdapter{

--- a/adapters/sharethrough/sharethrough.go
+++ b/adapters/sharethrough/sharethrough.go
@@ -15,8 +15,8 @@ const strVersion = 5
 func NewSharethroughBidder(endpoint string) *SharethroughAdapter {
 	return &SharethroughAdapter{
 		AdServer: StrOpenRTBTranslator{
-			UriHelper: StrUriHelper{BaseURI: endpoint},
-			Util:      Util{},
+			UriHelper: StrUriHelper{BaseURI: endpoint, Clock: Clock{}},
+			Util:      Util{Clock: Clock{}},
 			UserAgentParsers: UserAgentParsers{
 				ChromeVersion:    regexp.MustCompile(`Chrome\/(?P<ChromeVersion>\d+)`),
 				ChromeiOSVersion: regexp.MustCompile(`CriOS\/(?P<chromeiOSVersion>\d+)`),

--- a/adapters/sharethrough/sharethrough_test.go
+++ b/adapters/sharethrough/sharethrough_test.go
@@ -50,8 +50,8 @@ func TestNewSharethroughBidder(t *testing.T) {
 			input: "test endpoint",
 			output: SharethroughAdapter{
 				AdServer: StrOpenRTBTranslator{
-					UriHelper: StrUriHelper{BaseURI: "test endpoint"},
-					Util:      Util{},
+					UriHelper: StrUriHelper{BaseURI: "test endpoint", Clock: Clock{}},
+					Util:      Util{Clock: Clock{}},
 					UserAgentParsers: UserAgentParsers{
 						ChromeVersion:    regexp.MustCompile(`Chrome\/(?P<ChromeVersion>\d+)`),
 						ChromeiOSVersion: regexp.MustCompile(`CriOS\/(?P<chromeiOSVersion>\d+)`),

--- a/adapters/sharethrough/utils_test.go
+++ b/adapters/sharethrough/utils_test.go
@@ -22,7 +22,7 @@ func TestGetAdMarkup(t *testing.T) {
 			inputResponse: []byte(`{"bidId": "bid", "adserverRequestId": "arid"}`),
 			inputParams:   &StrAdSeverParams{Pkey: "pkey"},
 			expectedSuccess: []string{
-				`<img src="//b.sharethrough.com/butler?type=s2s-win&arid=arid" />`,
+				`<img src="//b.sharethrough.com/butler?type=s2s-win&arid=arid&adReceivedAt=2019-09-12T11%3a29%3a00.000123456Z" />`,
 				`<div data-str-native-key="pkey" data-stx-response-name="str_response_bid"></div>`,
 				fmt.Sprintf(`<script>var str_response_bid = "%s"</script>`, base64.StdEncoding.EncodeToString([]byte(`{"bidId": "bid", "adserverRequestId": "arid"}`))),
 			},
@@ -61,7 +61,7 @@ func TestGetAdMarkup(t *testing.T) {
 		var strResp openrtb_ext.ExtImpSharethroughResponse
 		_ = json.Unmarshal(test.inputResponse, &strResp)
 
-		outputSuccess, outputError := Util{}.getAdMarkup(test.inputResponse, strResp, test.inputParams)
+		outputSuccess, outputError := Util{Clock: MockClock{}}.getAdMarkup(test.inputResponse, strResp, test.inputParams)
 		for _, markup := range test.expectedSuccess {
 			assert.Contains(outputSuccess, markup)
 		}


### PR DESCRIPTION
Send json body to the ad server with:
- a list of blocked domains under `badv`
- the max time allowed by the exchange to get a response
```
{
  "badv": ["domain1.com", "domain2.com"],
  "tmax": 500,
  "deadline": "2019-09-12T11:29:00.000123456Z"
}
```
- bid request new param: `adRequestAt`
- s2s-win beacon new param: `adReceivedAt`

https://www.pivotaltracker.com/story/show/168119135
https://www.pivotaltracker.com/story/show/168279691
https://www.pivotaltracker.com/story/show/168464554