### PR TITLE
Addressing review

### DIFF
--- a/adapters/sharethrough/butler_test.go
+++ b/adapters/sharethrough/butler_test.go
@@ -18,7 +18,6 @@ import (
 type MockUtil struct {
 	mockCanAutoPlayVideo func() bool
 	mockGdprApplies      func() bool
-	mockUsPrivacySignal  func() string
 	mockGetPlacementSize func() (uint64, uint64)
 	mockParseUserInfo    func() userInfo
 	UtilityInterface
@@ -30,10 +29,6 @@ func (m MockUtil) canAutoPlayVideo(userAgent string, parsers UserAgentParsers) b
 
 func (m MockUtil) gdprApplies(request *openrtb.BidRequest) bool {
 	return m.mockGdprApplies()
-}
-
-func (m MockUtil) getUsPrivacySignal(request *openrtb.BidRequest) string {
-	return m.mockUsPrivacySignal()
 }
 
 func (m MockUtil) getPlacementSize(imp openrtb.Imp, strImpParams openrtb_ext.ExtImpSharethrough) (height uint64, width uint64) {
@@ -163,7 +158,6 @@ func TestSuccessRequestFromOpenRTB(t *testing.T) {
 	mockUtil := MockUtil{
 		mockCanAutoPlayVideo: func() bool { return true },
 		mockGdprApplies:      func() bool { return true },
-		mockUsPrivacySignal:  func() string { return "ccpa_string" },
 		mockGetPlacementSize: func() (uint64, uint64) { return 100, 200 },
 		mockParseUserInfo:    func() userInfo { return userInfo{Consent: "ok", TtdUid: "ttduid", StxUid: "stxuid"} },
 	}
@@ -219,7 +213,6 @@ func TestFailureRequestFromOpenRTB(t *testing.T) {
 	mockUtil := MockUtil{
 		mockCanAutoPlayVideo: func() bool { return true },
 		mockGdprApplies:      func() bool { return true },
-		mockUsPrivacySignal:  func() string { return "ccpa_string" },
 		mockGetPlacementSize: func() (uint64, uint64) { return 100, 200 },
 		mockParseUserInfo:    func() userInfo { return userInfo{Consent: "ok", TtdUid: "ttduid", StxUid: "stxuid"} },
 	}
@@ -445,7 +438,7 @@ func TestBuildUri(t *testing.T) {
 				BidID:              "bid",
 				ConsentRequired:    true,
 				ConsentString:      "consent",
-				UsPrivacySignal:    "ccpa",
+				USPrivacySignal:    "ccpa",
 				InstantPlayCapable: true,
 				Iframe:             false,
 				Height:             20,

--- a/adapters/sharethrough/utils.go
+++ b/adapters/sharethrough/utils.go
@@ -23,7 +23,6 @@ const minSafariVersion = 10
 
 type UtilityInterface interface {
 	gdprApplies(*openrtb.BidRequest) bool
-	getUsPrivacySignal(*openrtb.BidRequest) string
 	parseUserInfo(*openrtb.User) userInfo
 
 	getAdMarkup([]byte, openrtb_ext.ExtImpSharethroughResponse, *StrAdSeverParams) (string, error)
@@ -210,19 +209,6 @@ func (u Util) gdprApplies(request *openrtb.BidRequest) bool {
 	}
 
 	return gdprApplies != 0
-}
-
-func (u Util) getUsPrivacySignal(request *openrtb.BidRequest) (ccpaSignal string) {
-	ccpaSignal = ""
-
-	if request.Regs != nil {
-		if jsonExtRegs, err := request.Regs.Ext.MarshalJSON(); err == nil {
-			// "" is the return value if error, so no need to handle
-			ccpaSignal, _ = jsonparser.GetString(jsonExtRegs, "us_privacy")
-		}
-	}
-
-	return
 }
 
 func (u Util) parseUserInfo(user *openrtb.User) (ui userInfo) {

--- a/adapters/sharethrough/utils_test.go
+++ b/adapters/sharethrough/utils_test.go
@@ -396,48 +396,6 @@ func TestGdprApplies(t *testing.T) {
 	}
 }
 
-func TestAppliesUsPrivacySignal(t *testing.T) {
-	bidRequestWithSignal := openrtb.BidRequest{
-		Regs: &openrtb.Regs{
-			Ext: []byte(`{"us_privacy": "ccpa_string"}`),
-		},
-	}
-	bidRequestEmptyCcpa := openrtb.BidRequest{
-		Regs: &openrtb.Regs{
-			Ext: []byte(``),
-		},
-	}
-	bidRequestEmptyRegs := openrtb.BidRequest{
-		Regs: &openrtb.Regs{},
-	}
-
-	tests := map[string]struct {
-		input    *openrtb.BidRequest
-		expected string
-	}{
-		"Return the string if set": {
-			input:    &bidRequestWithSignal,
-			expected: "ccpa_string",
-		},
-		"Return empty string if Regs empty": {
-			input:    &bidRequestEmptyCcpa,
-			expected: "",
-		},
-		"Return empty string if no Regs set": {
-			input:    &bidRequestEmptyRegs,
-			expected: "",
-		},
-	}
-
-	for testName, test := range tests {
-		t.Logf("Test case: %s\n", testName)
-		assert := assert.New(t)
-
-		output := Util{}.getUsPrivacySignal(test.input)
-		assert.Equal(test.expected, output)
-	}
-}
-
 func TestParseUserInfo(t *testing.T) {
 	tests := map[string]struct {
 		input    *openrtb.User


### PR DESCRIPTION
Changes:
- Rename `UsPrivacySignal` to `USPrivacySignal`
- Use built-in `ccpa.ReadPolicy` instead of rebuilding the logic in our own `getUsPrivacySignal`